### PR TITLE
Several improvements for PHP-Autoload-Manager

### DIFF
--- a/autoloadManager.php
+++ b/autoloadManager.php
@@ -342,7 +342,7 @@ class autoloadManager
         if (isset($classes[$className]))
         {
             @include_once $classes[$className];
-            if (class_exists($className, FALSE))
+            if (class_exists($className, FALSE) OR interface_exists($className, FALSE))
                 return self::CLASS_EXISTS;
             else
                 return self::CLASS_NOT_FOUND;

--- a/autoloadManager.php
+++ b/autoloadManager.php
@@ -309,7 +309,7 @@ class autoloadManager
             // be run, so we run them manually
             foreach ($remainingAutoloaders as $loader) {
                 call_user_func($loader, $className);
-                if (class_exists($className, FALSE) OR interface_exists($className, FALSE))
+                if ($this->classLoaded($className))
                     break;
             }
 
@@ -353,7 +353,7 @@ class autoloadManager
 
         // If our autoloader was moved then some other autoloaders have been called by makeSureThisIsLastAutoloader(),
         // so we must manually check if this class was not loaded by any of them, before continuing
-        if ($wasLastAutoloader === FALSE AND (class_exists($className, FALSE) OR interface_exists($className, FALSE))) {
+        if ($wasLastAutoloader === FALSE AND $this->classLoaded($className)) {
             return;
         }
 
@@ -410,7 +410,7 @@ class autoloadManager
         if (isset($classes[$className]))
         {
             @include_once $classes[$className];
-            if (class_exists($className, FALSE) OR interface_exists($className, FALSE))
+            if ($this->classLoaded($className))
                 return self::CLASS_EXISTS;
             else
                 return self::CLASS_NOT_FOUND;
@@ -420,6 +420,17 @@ class autoloadManager
             return self::CLASS_IS_NULL;
         }
         return self::CLASS_NOT_FOUND;
+    }
+
+    /**
+     * Checks if an entity that is loadable by PHP-Autoload-Manager was already included during this request
+     * @param $className
+     * @return bool
+     */
+    private function classLoaded($className)
+    {
+        return class_exists($className, FALSE) OR interface_exists($className, FALSE)
+            OR trait_exists($className, FALSE);
     }
 
 

--- a/autoloadManager.php
+++ b/autoloadManager.php
@@ -344,7 +344,7 @@ class autoloadManager
      * @throws Exception
      */
     public function loadClass($className)
-    {;
+    {
         // Make sure this autoloader is run last. This is important, because if there are additional autoloaders
         // afterwards that load other classes (that are not loadable via this autoloader) - then it will force this
         // autoloader to regenerate its autoload data file, which can result in poor performance on Windows

--- a/autoloadManager.php
+++ b/autoloadManager.php
@@ -308,6 +308,8 @@ class autoloadManager
             // be run, so we run them manually
             foreach ($remainingAutoloaders as $loader) {
                 call_user_func($loader, $className);
+                if (class_exists($className, FALSE) OR interface_exists($className, FALSE))
+                    break;
             }
 
             return FALSE;

--- a/autoloadManager.php
+++ b/autoloadManager.php
@@ -26,8 +26,8 @@
 if (!defined('T_NAMESPACE'))
 {
     /**
-     * This is just for backword compatibilty with previous versions
-     * Token -1 will never exists but we just want to avoid having undefined
+     * This is just for backwards compatibility with previous versions
+     * Token -1 will never exist but we just want to avoid having undefined
      * constant
      */
     define('T_NAMESPACE', -1);
@@ -114,7 +114,6 @@ class autoloadManager
      *
      * @param string $saveFile    Path where autoload files will be saved
      * @param int    $scanOptions Scan options
-     * @return void
      */
     public function __construct($saveFile = null, $scanOptions = self::SCAN_ONCE)
     {
@@ -135,7 +134,7 @@ class autoloadManager
     /**
      * Set the path where autoload files are saved
      *
-     * @param string $path path where autoload files will be saved
+     * @param string $pathToFile path where autoload files will be saved
      */
     public function setSaveFile($pathToFile)
     {
@@ -182,6 +181,7 @@ class autoloadManager
      * Add a new folder to parse
      *
      * @param string $path Root path to process
+     * @throws Exception
      */
     public function addFolder($path)
     {
@@ -199,6 +199,7 @@ class autoloadManager
      * Exclude a folder from the parsing
      *
      * @param string $path Folder to exclude
+     * @throws Exception
      */
     public function excludeFolder($path)
     {
@@ -423,7 +424,7 @@ class autoloadManager
 
 
     /**
-     * Parse every registred folders, regenerate autoload files and update the $_classes
+     * Parse every registered folders, regenerate autoload files and update the $_classes
      *
      * @return array Array containing all the classes found
      */
@@ -536,7 +537,6 @@ class autoloadManager
      * File is generated under the _savePath folder.
      *
      * @param array  $classes Contains all the classes found and the corresponding filename (e.g. {$className} => {fileName})
-     * @param string $folder Folder to process
      * @return void
      */
     private function saveToFile(array $classes)
@@ -571,7 +571,7 @@ class autoloadManager
      * Refreshes an already generated cache file
      * This solves problems with previously unexistant classes that
      * have been made available after.
-     * The optimize functionnality will look at all null values of
+     * The optimize functionality will look at all null values of
      * the available classes and does a new parse. if it founds that
      * there are classes that has been made available, it will update
      * the file.


### PR DESCRIPTION
The improvements include:
- autoloadManager::generate() now returns a boolean value - TRUE if no errors occurred, FALSE otherwise.
  You can get a list of errors using autoloadManager::getErrors() and check for errors using autoloadManager::hasErrors()
- When regenerating autoload file on class load - throws an exception if a class with the same name is specified in two or more files.
  When generating autoload file via autoloadManager::generate() - it returns FALSE in such case. A list of duplicate class files can be retrieved via autoloadManager::getErrors()
- When saving autoload file - creates directories along the way, if they are not yet created
- If a class file has been moved or renamed - rebuild autoload file
- Performance fix: when interfaces were being used - they would always trigger the autoload file to be regenerated
- Make sure that PHP-Autoload-Manager autoloader is always run last in the spl_autoload chain
